### PR TITLE
Add Mailer Preview to application ignore paths

### DIFF
--- a/src/Command/PreloaderCommand.php
+++ b/src/Command/PreloaderCommand.php
@@ -139,7 +139,7 @@ class PreloaderCommand extends Command
             }
         }
 
-        $ignorePaths = ['src\/Console', 'src\/Command'];
+        $ignorePaths = ['src\/Console', 'src\/Command', 'src\/Mailer\/Preview'];
         if (!$args->getOption('phpunit')) {
             $ignorePaths[] = 'tests\/';
         }


### PR DESCRIPTION
Mailer Preview Classes are a feature of the [CakePHP debug kit](https://book.cakephp.org/debugkit/4/en/index.html#creating-preview-classes). 

It's extends from debug kit and that is in require-dev and not available on `composer install --no-dev`. And these classes are only use for developing mails.