### PR TITLE
Only load classes and function files

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,46 @@
+name: Merge
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  run:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        operating-system: [ ubuntu-20.04 ]
+        php-versions: ['8.0']
+
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, xdebug
+
+      - name: PHP Version
+        run: php -v
+
+      - name: Install dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: |
+          composer validate
+          composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Test
+        run: vendor/bin/phpunit
+
+      - name: Report Coverage
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          composer check
+          echo ${{ matrix.php-versions }}
+          export CODECOVERAGE=1 && vendor/bin/phpunit --verbose --coverage-clover=clover.xml
+          vendor/bin/php-coveralls --coverage_clover=clover.xml -v

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   run:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-20.04 ]
-        php-versions: ['7.4', '8.0']
+        php-versions: ['7.4', '8.0', '8.1']
 
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -48,3 +48,31 @@ jobs:
           echo ${{ matrix.php-versions }}
           export CODECOVERAGE=1 && vendor/bin/phpunit --verbose --coverage-clover=clover.xml
           vendor/bin/php-coveralls --coverage_clover=clover.xml -v
+  #
+  # CakePHP version compatability
+  #
+  compatibility:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ['~4.2.0', '^4.3']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          extensions: mbstring, intl
+
+      - name: PHP Version
+        run: php -v
+
+      - name: CakePHP ${{matrix.version}} Compatability
+        run: |
+          composer self-update
+          rm -rf composer.lock
+          composer require cakephp/cakephp:${{matrix.version}} --no-update
+          composer install --prefer-dist --no-progress
+          composer test

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,8 +1,6 @@
-name: Build
+name: Pull Request
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
 
 jobs:
@@ -75,3 +73,26 @@ jobs:
           composer require cakephp/cakephp:${{matrix.version}} --no-update
           composer install --prefer-dist --no-progress
           composer test
+  #
+  # Verify we can run php with opcache preload
+  #
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract Branch Name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - name: Docker Build
+        run: cd tests && docker build -t cakepreloader:test . --no-cache --BRANCH=dev-${{ steps.extract_branch.outputs.branch }}
+      - name: Docker Run
+        run: docker run -d cakepreloader:test
+      - name: Test Container
+        run: |
+          if docker ps | grep "cakepreloader:test"; then
+            echo "container is running"
+          else
+            echo "container is not running"
+            docker run cakepreloader:test && exit 1
+          fi
+

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -83,7 +83,7 @@ jobs:
         id: branch-name
         uses: tj-actions/branch-names@v5.1
       - name: Docker Build
-        run: docker build -t cakepreloader:test tests/Dockerfile --no-cache --build-arg BRANCH=dev-${{ steps.branch-name.outputs.current_branch }}
+        run: docker build -t cakepreloader:test tests/ --no-cache --build-arg BRANCH=dev-${{ steps.branch-name.outputs.current_branch }}
       - name: Docker Run
         run: docker run -d cakepreloader:test
       - name: Test Container

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -79,9 +79,11 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: nelonoel/branch-name@v1
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v5.1
       - name: Docker Build
-        run: docker build -t cakepreloader:test tests/Dockerfile --no-cache --build-arg BRANCH=dev-${BRANCH_NAME}
+        run: docker build -t cakepreloader:test tests/Dockerfile --no-cache --build-arg BRANCH=dev-${{ steps.branch-name.outputs.current_branch }}
       - name: Docker Run
         run: docker run -d cakepreloader:test
       - name: Test Container

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -84,7 +84,7 @@ jobs:
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
       - name: Docker Build
-        run: docker build -t cakepreloader:test tests/Dockerfile --no-cache --BRANCH=dev-${{ steps.extract_branch.outputs.branch }}
+        run: docker build -t cakepreloader:test tests/Dockerfile --no-cache --build-arg BRANCH=dev-${{ steps.extract_branch.outputs.branch }}
       - name: Docker Run
         run: docker run -d cakepreloader:test
       - name: Test Container

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -84,7 +84,7 @@ jobs:
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
       - name: Docker Build
-        run: cd tests && docker build -t cakepreloader:test . --no-cache --BRANCH=dev-${{ steps.extract_branch.outputs.branch }}
+        run: docker build -t cakepreloader:test tests/Dockerfile --no-cache --BRANCH=dev-${{ steps.extract_branch.outputs.branch }}
       - name: Docker Run
         run: docker run -d cakepreloader:test
       - name: Test Container

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -79,12 +79,9 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Extract Branch Name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
+      - uses: nelonoel/branch-name@v1
       - name: Docker Build
-        run: docker build -t cakepreloader:test tests/Dockerfile --no-cache --build-arg BRANCH=dev-${{ steps.extract_branch.outputs.branch }}
+        run: docker build -t cakepreloader:test tests/Dockerfile --no-cache --build-arg BRANCH=dev-${BRANCH_NAME}
       - name: Docker Run
         run: docker run -d cakepreloader:test
       - name: Test Container

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -79,6 +79,8 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Get branch name
         id: branch-name
         uses: tj-actions/branch-names@v5.1

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ files. Goals:
 composer packages.
 - Provide a simplistic API for writing a custom preloader.
 
-Any files which are not classes (i.e. Interfaces, Traits, Abstract Classes) are not added to the preloader. These will
-be added to the opcache preload if they are required by another class. Function files are loaded using
+Any files which are not classes (i.e. Interfaces, Traits, Abstract Classes) are not added to the preload file. These 
+will be added automically by PHPs opcache preload if they are required by another class. Function files are loaded using
 `opcache_compile_file` instead of `require_once`.
 
 For an alternative approach, checkout [DarkGhostHunter/Preloader](https://github.com/DarkGhostHunter/Preloader).

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Options:
 --name          The preload file path. (default: ROOT . DS . 'preload.php')
 --packages      A comma separated list of packages (e.g. vendor-name/package-name) to add to the preloader
 --plugins       A comma separated list of your plugins to load or `*` to load all plugins/*
+--cli           Should the preloader file exit when run via the php-cli? (default: true)
 --quiet, -q     Enable quiet output.
 --verbose, -v   Enable verbose output.
 ```
@@ -171,11 +172,11 @@ ab -n 10000 -c 10 http://localhost:8080/public/actors.json
 
 I ran each 3 times:
 
-| Type      | Run 1 | Run 2 | Run 3 |
-| ----------- | ----------- | ----------- | ----------- |
-| No Preload | 301.30 [#/sec] (mean) |  335.12 [#/sec] (mean) | 322.41 [#/sec] (mean) |
-| `CAKE` only | 447.92 [#/sec] (mean) |  448.48 [#/sec] (mean) | 446.53 [#/sec] (mean) |
-| `CAKE` + `APP` | 457.62 [#/sec] (mean) |  455.40 [#/sec] (mean) | 394.89 [#/sec] (mean) |
+| Type           | Run 1                 | Run 2                 | Run 3                 |
+|----------------|-----------------------|-----------------------|-----------------------|
+| No Preload     | 301.30 [#/sec] (mean) | 335.12 [#/sec] (mean) | 322.41 [#/sec] (mean) |
+| `CAKE` only    | 447.92 [#/sec] (mean) | 448.48 [#/sec] (mean) | 446.53 [#/sec] (mean) |
+| `CAKE` + `APP` | 457.62 [#/sec] (mean) | 455.40 [#/sec] (mean) | 394.89 [#/sec] (mean) |
 
 ## Tests / Analysis
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ files. Goals:
 composer packages.
 - Provide a simplistic API for writing a custom preloader.
 
+Any files which are not classes (i.e. Interfaces, Traits, Abstract Classes) are not added to the preloader. These will
+be added to the opcache preload if they are required by another class. Function files are loaded using
+`opcache_compile_file` instead of `require_once`.
+
 For an alternative approach, checkout [DarkGhostHunter/Preloader](https://github.com/DarkGhostHunter/Preloader).
 
 For an OPCache UI, checkout [amnuts/opcache-gui](https://github.com/amnuts/opcache-gui).
-
-Any files which are not classes (i.e. Interfaces, Traits, Abstract Classes) are not added to the preloader. These will 
-be added to the opcache preload if they are required by another class. Function files are loaded using 
-`opcache_compile_file` instead of `require_once`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build](https://github.com/cnizzardini/cakephp-preloader/actions/workflows/php.yml/badge.svg)](https://github.com/cnizzardini/cakephp-preloader/actions/workflows/php.yml)
 [![Coverage Status](https://coveralls.io/repos/github/cnizzardini/cakephp-preloader/badge.svg?branch=main)](https://coveralls.io/github/cnizzardini/cakephp-preloader?branch=main)
 [![License: MIT](https://img.shields.io/badge/license-mit-blue)](LICENSE.md)
-[![CakePHP](https://img.shields.io/badge/cakephp-%3E%3D%204.0-red?logo=cakephp)](https://book.cakephp.org/4/en/index.html)
+[![CakePHP](https://img.shields.io/badge/cakephp-%3E%3D%204.2-red?logo=cakephp)](https://book.cakephp.org/4/en/index.html)
 [![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.4-8892BF.svg?logo=php)](https://php.net/)
 
 An OPCache preloader for CakePHP.
@@ -22,6 +22,10 @@ composer packages.
 For an alternative approach, checkout [DarkGhostHunter/Preloader](https://github.com/DarkGhostHunter/Preloader).
 
 For an OPCache UI, checkout [amnuts/opcache-gui](https://github.com/amnuts/opcache-gui).
+
+Any files which are not classes (i.e. Interfaces, Traits, Abstract Classes) are not added to the preloader. These will 
+be added to the opcache preload if they are required by another class. Function files are loaded using 
+`opcache_compile_file` instead of `require_once`.
 
 ## Installation
 
@@ -70,7 +74,7 @@ prefer handling configurations another way read the CakePHP documentation on
 
 ### Examples:
 
-Default loads in CakePHP core files excluding TestSuite, Console, Command, and Shell namespaces. Preload file is
+Default loads in CakePHP core files excluding TestSuite, Console, Command, and Shell namespaces. The preload file is 
 written to `ROOT . DS . 'preload.php'`:
 
 ```console

--- a/src/Command/PreloaderCommand.php
+++ b/src/Command/PreloaderCommand.php
@@ -57,7 +57,7 @@ class PreloaderCommand extends Command
         $path = $args->getOption('name') ?? Configure::read('PreloaderConfig.name');
         $path = !empty($path) ? $path : ROOT . DS . 'preload.php';
 
-        $this->preloader->ignoreCli((bool) $args->getOption('cli'));
+        $this->preloader->ignoreCli((bool)$args->getOption('cli'));
         $result = $this->preloader->write($path);
 
         if ($result) {

--- a/src/Command/PreloaderCommand.php
+++ b/src/Command/PreloaderCommand.php
@@ -57,6 +57,7 @@ class PreloaderCommand extends Command
         $path = $args->getOption('name') ?? Configure::read('PreloaderConfig.name');
         $path = !empty($path) ? $path : ROOT . DS . 'preload.php';
 
+        $this->preloader->ignoreCli($args->getOption('cli'));
         $result = $this->preloader->write($path);
 
         if ($result) {

--- a/src/Command/PreloaderCommand.php
+++ b/src/Command/PreloaderCommand.php
@@ -221,6 +221,11 @@ class PreloaderCommand extends Command
             ])
             ->addOption('packages', [
                 'help' => 'A comma separated list of packages (e.g. vendor-name/package-name) to add to the preloader',
+            ])
+            ->addOption('cli', [
+                'help' => 'Should the preloader load for php-cli?',
+                'boolean' => true,
+                'default' => false
             ]);
 
         if (defined('TEST')) {

--- a/src/Command/PreloaderCommand.php
+++ b/src/Command/PreloaderCommand.php
@@ -226,7 +226,7 @@ class PreloaderCommand extends Command
             ->addOption('cli', [
                 'help' => 'Should the preloader load for php-cli?',
                 'boolean' => true,
-                'default' => false
+                'default' => false,
             ]);
 
         if (defined('TEST')) {

--- a/src/Command/PreloaderCommand.php
+++ b/src/Command/PreloaderCommand.php
@@ -57,7 +57,7 @@ class PreloaderCommand extends Command
         $path = $args->getOption('name') ?? Configure::read('PreloaderConfig.name');
         $path = !empty($path) ? $path : ROOT . DS . 'preload.php';
 
-        $this->preloader->ignoreCli((bool)$args->getOption('cli'));
+        $this->preloader->allowCli((bool)$args->getOption('cli'));
         $result = $this->preloader->write($path);
 
         if ($result) {
@@ -224,7 +224,7 @@ class PreloaderCommand extends Command
                 'help' => 'A comma separated list of packages (e.g. vendor-name/package-name) to add to the preloader',
             ])
             ->addOption('cli', [
-                'help' => 'Should the preloader load for php-cli?',
+                'help' => 'Should the preloader file load when run via php-cli?',
                 'boolean' => true,
                 'default' => false,
             ]);

--- a/src/Command/PreloaderCommand.php
+++ b/src/Command/PreloaderCommand.php
@@ -57,7 +57,7 @@ class PreloaderCommand extends Command
         $path = $args->getOption('name') ?? Configure::read('PreloaderConfig.name');
         $path = !empty($path) ? $path : ROOT . DS . 'preload.php';
 
-        $this->preloader->ignoreCli($args->getOption('cli'));
+        $this->preloader->ignoreCli((bool) $args->getOption('cli'));
         $result = $this->preloader->write($path);
 
         if ($result) {

--- a/src/Preloader.php
+++ b/src/Preloader.php
@@ -177,7 +177,7 @@ class Preloader
     /**
      * Returns false if the file name is not PSR-4, true if it as and is a class, null otherwise.
      *
-     * @param SplFileInfo $file Instance of SplFileInfo
+     * @param \SplFileInfo $file Instance of SplFileInfo
      * @return bool|null
      */
     private function isClass(SplFileInfo $file): ?bool

--- a/src/Preloader.php
+++ b/src/Preloader.php
@@ -20,9 +20,9 @@ use SplFileInfo;
 class Preloader
 {
     /**
-     * @var bool Should the preload file return early (not load) when run by php-cli?
+     * @var bool Should the preload file continue when run via php-cli?
      */
-    private bool $ignoreCli = true;
+    private bool $allowCli = false;
 
     /**
      * An array of PreloadResource instances
@@ -110,12 +110,12 @@ class Preloader
     }
 
     /**
-     * @param bool $bool Should the preload file return early (not load) when run by php-cli?
+     * @param bool $bool Should the preload file continue when run via php-cli?
      * @return $this
      */
-    public function ignoreCli(bool $bool)
+    public function allowCli(bool $bool)
     {
-        $this->ignoreCli = $bool;
+        $this->allowCli = $bool;
 
         return $this;
     }
@@ -132,10 +132,10 @@ class Preloader
 
         $title = sprintf("# Preload Generated at %s \n", FrozenTime::now());
 
-        if ($this->ignoreCli) {
-            $ignores = "['cli', 'phpdbg']";
-        } else {
+        if ($this->allowCli) {
             $ignores = "['phpdbg']";
+        } else {
+            $ignores = "['cli', 'phpdbg']";
         }
 
         echo "<?php\n\n";

--- a/src/Preloader.php
+++ b/src/Preloader.php
@@ -9,7 +9,6 @@ use Cake\Filesystem\Filesystem;
 use Cake\I18n\FrozenTime;
 use Cake\Utility\Inflector;
 use CakePreloader\Exception\ResourceNotFoundException;
-use PHPStan\Analyser\IgnoredError;
 use RuntimeException;
 use SplFileInfo;
 
@@ -84,7 +83,7 @@ class Preloader
             $result = $this->isClass($file);
             if ($result === true) {
                 $this->preloadResources[] = new PreloadResource('require_once', $file->getPathname());
-            } else if ($result === false) {
+            } elseif ($result === false) {
                 $this->preloadResources[] = new PreloadResource('opcache_compile_file', $file->getPathname());
             }
         }
@@ -111,9 +110,7 @@ class Preloader
     }
 
     /**
-     * Should the preload file return early (not load) when run by php-cli?
-     *
-     * @param bool $bool
+     * @param bool $bool Should the preload file return early (not load) when run by php-cli?
      * @return $this
      */
     public function ignoreCli(bool $bool)
@@ -177,6 +174,12 @@ class Preloader
         return $content;
     }
 
+    /**
+     * Returns false if the file name is not PSR-4, true if it as and is a class, null otherwise.
+     *
+     * @param SplFileInfo $file Instance of SplFileInfo
+     * @return bool|null
+     */
     private function isClass(SplFileInfo $file): ?bool
     {
         if (Inflector::camelize($file->getFilename()) !== $file->getFilename()) {
@@ -189,7 +192,7 @@ class Preloader
         }
 
         $className = str_replace('.php', '', $file->getFilename());
-        if (strstr($contents, "class $className") && strstr($contents, "namespace")) {
+        if (strstr($contents, "class $className") && strstr($contents, 'namespace')) {
             return true;
         }
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,16 @@
+FROM cnizzardini/php-fpm-alpine:8.0-latest
+
+ARG BRANCH=main
+
+COPY php.ini /usr/local/etc/php/php.ini
+
+WORKDIR /srv/app
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+RUN composer create-project --prefer-dist --no-interaction cakephp/app:~4.2 .
+RUN composer require cnizzardini/cakephp-preloader:$BRANCH
+RUN bin/cake plugin load CakePreloader
+RUN bin/cake preloader
+
+CMD ["php-fpm"]

--- a/tests/TestCase/Command/PreloaderCommandTest.php
+++ b/tests/TestCase/Command/PreloaderCommandTest.php
@@ -26,8 +26,8 @@ class PreloaderCommandTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        //@unlink(ROOT . DS . 'preload.php');
-        //@unlink(ROOT . DS . 'a-unique-name.php');
+        @unlink(ROOT . DS . 'preload.php');
+        @unlink(ROOT . DS . 'a-unique-name.php');
     }
 
     public function test_default(): void

--- a/tests/TestCase/Command/PreloaderCommandTest.php
+++ b/tests/TestCase/Command/PreloaderCommandTest.php
@@ -36,9 +36,11 @@ class PreloaderCommandTest extends TestCase
         $this->assertExitSuccess();
         $this->assertFileExists(ROOT . DS . 'preload.php');
 
+        /** @var string $preload */
         $preload = file_get_contents(ROOT . DS . 'preload.php');
+        $this->assertTrue(is_string($preload));
 
-        $lines = [
+        $contains = [
             'vendor/autoload.php',
             'vendor/cakephp/cakephp/src/Cache/Cache.php',
             'vendor/cakephp/cakephp/src/basics.php',
@@ -46,8 +48,19 @@ class PreloaderCommandTest extends TestCase
             'opcache_compile_file'
         ];
 
-        foreach ($lines as $file) {
+        foreach ($contains as $file) {
             $this->assertStringContainsString($file, $preload);
+        }
+
+        $excludes = [
+            'vendor/cakephp/cakephp/src/Database/Exception.php',
+            'vendor/cakephp/cakephp/src/Database/Expression/Comparison.php',
+            'vendor/cakephp/cakephp/src/Http/ControllerFactory.php',
+            'vendor/cakephp/cakephp/src/Routing/Exception/MissingControllerException.php',
+        ];
+
+        foreach ($excludes as $file) {
+            $this->assertStringNotContainsString($file, $preload);
         }
     }
 
@@ -64,6 +77,7 @@ class PreloaderCommandTest extends TestCase
     {
         $this->exec('preloader --app --phpunit');
         $this->assertExitSuccess();
+        /** @var string $preload */
         $preload = file_get_contents(ROOT . DS . 'preload.php');
         $this->assertStringContainsString('test_app/src/Application.php', $preload);
     }
@@ -71,6 +85,7 @@ class PreloaderCommandTest extends TestCase
     public function test_with_one_plugin(): void
     {
         $this->exec('preloader --plugins=MyPluginOneZz --phpunit');
+        /** @var string $preload */
         $preload = file_get_contents(ROOT . DS . 'preload.php');
         $this->assertStringContainsString('plugins/MyPluginOneZz/src/Plugin.php', $preload);
     }
@@ -78,6 +93,7 @@ class PreloaderCommandTest extends TestCase
     public function test_with_multiple_plugins(): void
     {
         $this->exec('preloader --plugins=MyPluginOneZz,MyPluginTwoZz --phpunit');
+        /** @var string $preload */
         $preload = file_get_contents(ROOT . DS . 'preload.php');
         $this->assertStringContainsString('plugins/MyPluginOneZz/src/Plugin.php', $preload);
         $this->assertStringContainsString('plugins/MyPluginTwoZz/src/Plugin.php', $preload);
@@ -86,6 +102,7 @@ class PreloaderCommandTest extends TestCase
     public function test_with_plugins_wildcard(): void
     {
         $this->exec('preloader --plugins=* --phpunit');
+        /** @var string $preload */
         $preload = file_get_contents(ROOT . DS . 'preload.php');
         $this->assertStringContainsString('plugins/MyPluginOneZz/src/Plugin.php', $preload);
         $this->assertStringContainsString('plugins/MyPluginTwoZz/src/Plugin.php', $preload);
@@ -96,6 +113,7 @@ class PreloaderCommandTest extends TestCase
         $this->exec('preloader --packages=vendorone/packageone --phpunit');
         $this->assertExitSuccess();
 
+        /** @var string $preload */
         $preload = file_get_contents(ROOT . DS . 'preload.php');
         $this->assertStringContainsString('vendorone/packageone/src/VendorOnePackageOneTestClassZz.php', $preload);
     }
@@ -105,6 +123,7 @@ class PreloaderCommandTest extends TestCase
         $this->exec('preloader --packages=vendorone/packageone,vendortwo/packagetwo --phpunit');
         $this->assertExitSuccess();
 
+        /** @var string $preload */
         $preload = file_get_contents(ROOT . DS . 'preload.php');
         $this->assertStringContainsString('vendorone/packageone/src/VendorOnePackageOneTestClassZz.php', $preload);
         $this->assertStringContainsString('vendortwo/packagetwo/src/VendorTwoPackageTwoTestClassZz.php', $preload);
@@ -132,6 +151,7 @@ class PreloaderCommandTest extends TestCase
         $this->exec('preloader');
         $this->assertEventFired('CakePreloader.beforeWrite');
 
+        /** @var string $preload */
         $preload = file_get_contents(ROOT . DS . 'preload.php');
         $this->assertStringContainsString(__FILE__, $preload);
     }
@@ -146,6 +166,7 @@ class PreloaderCommandTest extends TestCase
         $this->assertExitSuccess();
         $this->assertFileExists($path);
 
+        /** @var string $preload */
         $preload = file_get_contents($path);
 
         // app

--- a/tests/TestCase/Command/PreloaderCommandTest.php
+++ b/tests/TestCase/Command/PreloaderCommandTest.php
@@ -26,8 +26,8 @@ class PreloaderCommandTest extends TestCase
     public function tearDown(): void
     {
         parent::tearDown();
-        @unlink(ROOT . DS . 'preload.php');
-        @unlink(ROOT . DS . 'a-unique-name.php');
+        //@unlink(ROOT . DS . 'preload.php');
+        //@unlink(ROOT . DS . 'a-unique-name.php');
     }
 
     public function test_default(): void
@@ -39,6 +39,8 @@ class PreloaderCommandTest extends TestCase
         /** @var string $preload */
         $preload = file_get_contents(ROOT . DS . 'preload.php');
         $this->assertTrue(is_string($preload));
+
+        $this->assertStringContainsString("if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true))", $preload);
 
         $contains = [
             'vendor/autoload.php',
@@ -62,6 +64,18 @@ class PreloaderCommandTest extends TestCase
         foreach ($excludes as $file) {
             $this->assertStringNotContainsString($file, $preload);
         }
+    }
+
+    public function test_cli(): void
+    {
+        $this->exec('preloader --cli');
+        $this->assertExitSuccess();
+        $this->assertFileExists(ROOT . DS . 'preload.php');
+
+        /** @var string $preload */
+        $preload = file_get_contents(ROOT . DS . 'preload.php');
+        $this->assertTrue(is_string($preload));
+        $this->assertStringContainsString("if (in_array(PHP_SAPI, ['phpdbg'], true))", $preload);
     }
 
     public function test_with_name(): void

--- a/tests/php.ini
+++ b/tests/php.ini
@@ -1,0 +1,26 @@
+;
+; Development
+;
+extension=intl.so
+extension=pdo_mysql.so
+extension=sodium
+extension=zip.so
+zend_extension=opcache.so
+
+[php]
+session.auto_start = Off
+short_open_tag = Off
+opcache.interned_strings_buffer = 16
+opcache.max_accelerated_files = 20000
+opcache.memory_consumption = 256
+opcache.enable_cli = 0
+opcache.enable = 1
+; set higher on production, see https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.revalidate-freq
+opcache.revalidate_freq = 360
+opcache.enable_file_override = 1
+opcache.max_file_size = 1000000
+opcache.preload_user=root
+opcache.preload=/srv/app/preload.php
+realpath_cache_size = 4096K
+realpath_cache_ttl = 600
+expose_php = off

--- a/tests/test_app/vendor/vendorone/packageone/src/VendorOnePackageOneTestClassZz.php
+++ b/tests/test_app/vendor/vendorone/packageone/src/VendorOnePackageOneTestClassZz.php
@@ -1,4 +1,5 @@
 <?php
+namespace VendorOne\PackageOne;
 
 class VendorOnePackageOneTestClassZz
 {

--- a/tests/test_app/vendor/vendortwo/packagetwo/src/VendorTwoPackageTwoTestClassZz.php
+++ b/tests/test_app/vendor/vendortwo/packagetwo/src/VendorTwoPackageTwoTestClassZz.php
@@ -1,4 +1,5 @@
 <?php
+namespace VendorTwo\PackageTwo;
 
 class VendorTwoPackageTwoTestClassZz
 {


### PR DESCRIPTION
- Resolves #9 
- Adds new `--cli` option
- Only loads Classes and function files now
- Adds docker test to ensure php-fpm/cakephp loads with opcache preload enabled.