### PR TITLE
Remove scripts support because of cakephp 4.5

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -2,7 +2,7 @@ name: Merge
 
 on:
   push:
-    branches: [ main ]
+    branches: [ v0 ]
 
 jobs:
   run:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -6,14 +6,12 @@ on:
 
 jobs:
   run:
-
+    name: PHP ${{ matrix.php-versions }} Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
         operating-system: [ ubuntu-20.04 ]
         php-versions: ['8.0']
-
-    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -71,7 +71,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        operating-system: [ ubuntu-20.04 ]
         version: ['~4.2.0', '~4.3.0', '~4.4.0', '^4.5']
     steps:
       - name: Checkout

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-20.04 ]
-        php-versions: ['8.1', '8.2']
+        php-versions: ['7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-20.04 ]
-        php-versions: ['8.1']
+        php-versions: ['7.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['^4.5']
+        version: ['~4.2.0', '~4.3.0', '~4.4.0', '^4.5']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -79,7 +79,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '7.4'
           extensions: mbstring, intl, curl
 
       - name: PHP Version
@@ -93,8 +93,8 @@ jobs:
           composer install --prefer-dist --no-progress
           composer test
 
-  integration_test:
-    name: Integration Test (Docker)
+  integration_test_cake_43:
+    name: Integration Test CakePHP ~4.3.0
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -103,7 +103,29 @@ jobs:
         id: branch-name
         uses: tj-actions/branch-names@v5.1
       - name: Docker Build
-        run: docker build -t cakepreloader:test tests/ --no-cache --build-arg BRANCH=dev-${{ steps.branch-name.outputs.current_branch }}
+        run: docker build -t cakepreloader:test tests/ --no-cache --build-arg CAKE_VERSION=~4.3.0 --build-arg BRANCH=dev-${{ steps.branch-name.outputs.current_branch }}
+      - name: Docker Run
+        run: docker run -d cakepreloader:test
+      - name: Test Container
+        run: |
+          if docker ps | grep "cakepreloader:test"; then
+            echo "container is running"
+          else
+            echo "container is not running"
+            exit 1
+          fi
+
+  integration_test_cake_45:
+    name: Integration Test CakePHP ^4.5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v5.1
+      - name: Docker Build
+        run: docker build -t cakepreloader:test tests/ --no-cache --build-arg CAKE_VERSION=^4.5 --build-arg BRANCH=dev-${{ steps.branch-name.outputs.current_branch }}
       - name: Docker Run
         run: docker run -d cakepreloader:test
       - name: Test Container

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-22.04 ]
-        php-versions: ['7.4', '8.1', '8.2']
+        php-versions: ['7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: |
           composer validate
-          composer install --prefer-dist --no-progress --no-suggest
+          composer install --prefer-dist --no-progress
 
       - name: Test Suite + Static Analysis
         run: composer check

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -68,7 +68,7 @@ jobs:
           php-coveralls --coverage_clover=clover.xml -v     
 
   compatibility:
-    name: CakePHP ${{ matrix.cakephp-versions }} Test
+    name: CakePHP ${{ matrix.version }} Test
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        operating-system: [ ubuntu-22.04 ]
+        operating-system: [ ubuntu-20.04 ]
         php-versions: ['7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        operating-system: [ ubuntu-22.04 ]
+        operating-system: [ ubuntu-20.04 ]
         php-versions: ['7.4']
     steps:
       - name: Checkout

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-20.04 ]
-        php-versions: ['7.4', '8.0', '8.1', '8.2']
+        php-versions: ['8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-20.04 ]
-        php-versions: ['7.4']
+        php-versions: ['8.1']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['~4.2.0', '~4.3.0', '~4.4.0', '^4.5']
+        version: ['^4.5']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -79,7 +79,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           extensions: mbstring, intl, curl
 
       - name: PHP Version

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,7 +25,6 @@ jobs:
         run: php -v
 
       - name: Install dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true'
         run: |
           composer validate
           composer install --prefer-dist --no-progress

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,7 +19,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, intl, xdebug
+          extensions: mbstring, intl, xdebug, curl
 
       - name: PHP Version
         run: php -v
@@ -30,7 +30,7 @@ jobs:
           composer install --prefer-dist --no-progress
 
       - name: Test Suite + Static Analysis
-        run: composer check
+        run: composer test
 
   coverage:
     name: Code Coverage

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,15 +4,13 @@ on:
   pull_request:
 
 jobs:
-  run:
-
+  test_and_analyze:
+    name: PHP ${{ matrix.php-versions }} Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        operating-system: [ ubuntu-20.04 ]
-        php-versions: ['7.4', '8.0', '8.1']
-
-    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+        operating-system: [ ubuntu-22.04 ]
+        php-versions: ['7.4', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -32,27 +30,49 @@ jobs:
           composer validate
           composer install --prefer-dist --no-progress --no-suggest
 
-      - name: Test (8.0)
-        if: ${{ matrix.php-versions != '7.4' }}
-        run: vendor/bin/phpunit
+      - name: Test Suite + Static Analysis
+        run: composer check
 
-      - name: Test + Coverage + Static Analysis (7.4 only)
-        if: ${{ matrix.php-versions == '7.4' }}
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          composer check
-          echo ${{ matrix.php-versions }}
-          export CODECOVERAGE=1 && vendor/bin/phpunit --verbose --coverage-clover=clover.xml
-          vendor/bin/php-coveralls --coverage_clover=clover.xml -v
-  #
-  # CakePHP version compatability
-  #
-  compatibility:
+  coverage:
+    name: Code Coverage
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['~4.2.0', '^4.3']
+        operating-system: [ ubuntu-22.04 ]
+        php-versions: ['7.4']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, xdebug
+
+      - name: PHP Version
+        run: php -v
+
+      - name: Install dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: |
+          composer validate
+          composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Code Coverage
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          composer global require php-coveralls/php-coveralls
+          export CODECOVERAGE=1 && vendor/bin/phpunit --coverage-clover=clover.xml
+          php-coveralls --coverage_clover=clover.xml -v     
+
+  compatibility:
+    name: CakePHP ${{ matrix.cakephp-versions }} Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ['~4.2.0', '~4.3.0', '~4.4.0', '^4.5']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -73,10 +93,9 @@ jobs:
           composer require cakephp/cakephp:${{matrix.version}} --no-update
           composer install --prefer-dist --no-progress
           composer test
-  #
-  # Verify we can run php with opcache preload
-  #
-  docker:
+
+  integration_test:
+    name: Integration Test (Docker)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -94,6 +113,6 @@ jobs:
             echo "container is running"
           else
             echo "container is not running"
-            docker run cakepreloader:test && exit 1
+            exit 1
           fi
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -71,6 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        operating-system: [ ubuntu-20.04 ]
         version: ['~4.2.0', '~4.3.0', '~4.4.0', '^4.5']
     steps:
       - name: Checkout

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,13 +4,15 @@ on:
   pull_request:
 
 jobs:
-  test_and_analyze:
-    name: PHP ${{ matrix.php-versions }} Test
+  run:
+
     runs-on: ubuntu-latest
     strategy:
       matrix:
         operating-system: [ ubuntu-20.04 ]
-        php-versions: ['7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.4', '8.0', '8.1']
+
+    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -19,35 +21,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, intl, curl
-
-      - name: PHP Version
-        run: php -v
-
-      - name: Install dependencies
-        run: |
-          composer validate
-          composer install --prefer-dist --no-progress
-
-      - name: Test Suite + Static Analysis
-        run: composer test
-
-  coverage:
-    name: Code Coverage
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        operating-system: [ ubuntu-20.04 ]
-        php-versions: ['7.4']
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, intl, xdebug, curl
+          extensions: mbstring, intl, xdebug
 
       - name: PHP Version
         run: php -v
@@ -58,20 +32,27 @@ jobs:
           composer validate
           composer install --prefer-dist --no-progress --no-suggest
 
-      - name: Code Coverage
+      - name: Test (8.0)
+        if: ${{ matrix.php-versions != '7.4' }}
+        run: vendor/bin/phpunit
+
+      - name: Test + Coverage + Static Analysis (7.4 only)
+        if: ${{ matrix.php-versions == '7.4' }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          composer global require php-coveralls/php-coveralls
-          export CODECOVERAGE=1 && vendor/bin/phpunit --coverage-clover=clover.xml
-          php-coveralls --coverage_clover=clover.xml -v     
-
+          composer check
+          echo ${{ matrix.php-versions }}
+          export CODECOVERAGE=1 && vendor/bin/phpunit --verbose --coverage-clover=clover.xml
+          vendor/bin/php-coveralls --coverage_clover=clover.xml -v
+  #
+  # CakePHP version compatability
+  #
   compatibility:
-    name: CakePHP ${{ matrix.version }} Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['~4.2.0', '~4.3.0', '~4.4.0', '^4.5']
+        version: ['~4.2.0', '^4.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -80,7 +61,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
-          extensions: mbstring, intl, curl
+          extensions: mbstring, intl
 
       - name: PHP Version
         run: php -v
@@ -92,9 +73,10 @@ jobs:
           composer require cakephp/cakephp:${{matrix.version}} --no-update
           composer install --prefer-dist --no-progress
           composer test
-
-  integration_test:
-    name: Integration Test (Docker)
+  #
+  # Verify we can run php with opcache preload
+  #
+  docker:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -112,6 +94,6 @@ jobs:
             echo "container is running"
           else
             echo "container is not running"
-            exit 1
+            docker run cakepreloader:test && exit 1
           fi
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,15 +4,13 @@ on:
   pull_request:
 
 jobs:
-  run:
-
+  test_and_analyze:
+    name: PHP ${{ matrix.php-versions }} Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
         operating-system: [ ubuntu-20.04 ]
-        php-versions: ['7.4', '8.0', '8.1']
-
-    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+        php-versions: ['7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -21,7 +19,35 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, intl, xdebug
+          extensions: mbstring, intl, curl
+
+      - name: PHP Version
+        run: php -v
+
+      - name: Install dependencies
+        run: |
+          composer validate
+          composer install --prefer-dist --no-progress
+
+      - name: Test Suite + Static Analysis
+        run: composer test
+
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        operating-system: [ ubuntu-20.04 ]
+        php-versions: ['7.4']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, xdebug, curl
 
       - name: PHP Version
         run: php -v
@@ -32,27 +58,20 @@ jobs:
           composer validate
           composer install --prefer-dist --no-progress --no-suggest
 
-      - name: Test (8.0)
-        if: ${{ matrix.php-versions != '7.4' }}
-        run: vendor/bin/phpunit
-
-      - name: Test + Coverage + Static Analysis (7.4 only)
-        if: ${{ matrix.php-versions == '7.4' }}
+      - name: Code Coverage
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          composer check
-          echo ${{ matrix.php-versions }}
-          export CODECOVERAGE=1 && vendor/bin/phpunit --verbose --coverage-clover=clover.xml
-          vendor/bin/php-coveralls --coverage_clover=clover.xml -v
-  #
-  # CakePHP version compatability
-  #
+          composer global require php-coveralls/php-coveralls
+          export CODECOVERAGE=1 && vendor/bin/phpunit --coverage-clover=clover.xml
+          php-coveralls --coverage_clover=clover.xml -v     
+
   compatibility:
+    name: CakePHP ${{ matrix.version }} Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['~4.2.0', '^4.3']
+        version: ['~4.2.0', '~4.3.0', '~4.4.0', '^4.5']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -61,7 +80,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
-          extensions: mbstring, intl
+          extensions: mbstring, intl, curl
 
       - name: PHP Version
         run: php -v
@@ -73,10 +92,9 @@ jobs:
           composer require cakephp/cakephp:${{matrix.version}} --no-update
           composer install --prefer-dist --no-progress
           composer test
-  #
-  # Verify we can run php with opcache preload
-  #
-  docker:
+
+  integration_test:
+    name: Integration Test (Docker)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -94,6 +112,6 @@ jobs:
             echo "container is running"
           else
             echo "container is not running"
-            docker run cakepreloader:test && exit 1
+            exit 1
           fi
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,7 +19,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, intl, xdebug, curl
+          extensions: mbstring, intl, curl
 
       - name: PHP Version
         run: php -v
@@ -47,7 +47,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: mbstring, intl, xdebug
+          extensions: mbstring, intl, xdebug, curl
 
       - name: PHP Version
         run: php -v
@@ -80,7 +80,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
-          extensions: mbstring, intl
+          extensions: mbstring, intl, curl
 
       - name: PHP Version
         run: php -v

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "license": "MIT",
     "keywords": ["cakephp","preload","preloader","opcache preloader","cakephp preloader", "cakephp opcache preloader"],
     "require": {
-        "php": "^7.4|^8.0",
-        "cakephp/cakephp": "^4.2"
+        "php": "^8.1",
+        "cakephp/cakephp": "^4.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.3",

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "license": "MIT",
     "keywords": ["cakephp","preload","preloader","opcache preloader","cakephp preloader", "cakephp opcache preloader"],
     "require": {
-        "php": "^8.1",
-        "cakephp/cakephp": "^4.5"
+        "php": "^7.4|^8.0",
+        "cakephp/cakephp": "^4.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.3",
@@ -52,7 +52,7 @@
     ],
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": false
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -49,5 +49,10 @@
             "name": "Chris Nizzardini",
             "role": "Developer"
         }
-    ]
+    ],
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "keywords": ["cakephp","preload","preloader","opcache preloader","cakephp preloader", "cakephp opcache preloader"],
     "require": {
-        "php": ">=7.4",
+        "php": "^7.4|^8.0",
         "cakephp/cakephp": "^4.2.0"
     },
     "require-dev": {
@@ -13,7 +13,7 @@
         "cakephp/cakephp-codesniffer": "^4.4",
         "phpmd/phpmd": "^2.10",
         "php-coveralls/php-coveralls": "^2.4",
-        "phpstan/phpstan": "^0.12.32"
+        "phpstan/phpstan": "^1.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "keywords": ["cakephp","preload","preloader","opcache preloader","cakephp preloader", "cakephp opcache preloader"],
     "require": {
         "php": "^7.4|^8.0",
-        "cakephp/cakephp": "^4.2.0"
+        "cakephp/cakephp": "^4.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.3",

--- a/src/Preloader.php
+++ b/src/Preloader.php
@@ -83,8 +83,6 @@ class Preloader
             $result = $this->isClass($file);
             if ($result === true) {
                 $this->preloadResources[] = new PreloadResource('require_once', $file->getPathname());
-            } elseif ($result === false) {
-                $this->preloadResources[] = new PreloadResource('opcache_compile_file', $file->getPathname());
             }
         }
 

--- a/src/Preloader.php
+++ b/src/Preloader.php
@@ -161,7 +161,7 @@ class Preloader
 
         if (!empty($scripts)) {
             echo "# Scripts \n";
-            echo implode('', $scripts ?? []);
+            echo implode('', $scripts);
         }
 
         $content = ob_get_contents();

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,6 +1,7 @@
 FROM cnizzardini/php-fpm-alpine:8.0-latest
 
 ARG BRANCH=main
+ARG CAKE_VERSION
 
 COPY php.ini /usr/local/etc/php/php.ini
 
@@ -8,7 +9,7 @@ WORKDIR /srv/app
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-RUN composer create-project --prefer-dist --no-interaction cakephp/app:~4.2.0 .
+RUN composer create-project --prefer-dist --no-interaction cakephp/app .
 RUN composer require cnizzardini/cakephp-preloader:$BRANCH
 RUN bin/cake plugin load CakePreloader
 RUN bin/cake preloader

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -11,6 +11,7 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 RUN composer create-project --prefer-dist --no-interaction cakephp/app .
 RUN composer require cnizzardini/cakephp-preloader:$BRANCH
 COPY plugins.php /srv/app/config/plugins.php
+RUN bin/cake plugin load CakePreloader
 RUN bin/cake preloader
 
 CMD ["php-fpm"]

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM cnizzardini/php-fpm-alpine:8.0-latest
+FROM cnizzardini/php-fpm-alpine:8.1-latest
 
 ARG BRANCH=main
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -9,11 +9,10 @@ WORKDIR /srv/app
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 RUN composer create-project --prefer-dist --no-interaction cakephp/app .
+RUN composer config minimum-stability dev
+RUN composer config prefer-stable true
 RUN composer require cnizzardini/cakephp-preloader:$BRANCH
-RUN sleep 5
 RUN bin/cake plugin load CakePreloader
-RUN sleep 1
 RUN bin/cake preloader
-RUN sleep 1
 
 CMD ["php-fpm"]

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -8,9 +8,9 @@ WORKDIR /srv/app
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-RUN composer create-project --prefer-dist --no-interaction cakephp/app:~4.2 .
+RUN composer create-project --prefer-dist --no-interaction cakephp/app:^4.5 .
 RUN composer require cnizzardini/cakephp-preloader:$BRANCH
-RUN bin/cake plugin load CakePreloader
+COPY plugins.php /srv/app/config/plugins.php
 RUN bin/cake preloader
 
 CMD ["php-fpm"]

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,6 +1,7 @@
 FROM cnizzardini/php-fpm-alpine:8.1-latest
 
 ARG BRANCH=main
+ARG CAKE_VERSION=~4.3.0
 
 COPY php.ini /usr/local/etc/php/php.ini
 
@@ -8,11 +9,11 @@ WORKDIR /srv/app
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-RUN composer create-project --prefer-dist --no-interaction cakephp/app:^4.5 .
+RUN composer create-project --prefer-dist --no-interaction cakephp/app:$CAKE_VERSION .
 RUN composer config minimum-stability dev
 RUN composer config prefer-stable true
-RUN composer update -W
-RUN composer require cnizzardini/cakephp-preloader:$BRANCH
+RUN composer update -W --no-cache
+RUN composer require cnizzardini/cakephp-preloader:$BRANCH  --no-cache
 RUN composer dump-autoload
 RUN bin/cake plugin load CakePreloader
 RUN bin/cake preloader

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /srv/app
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-RUN composer create-project --prefer-dist --no-interaction cakephp/app .
+RUN composer create-project --prefer-dist --no-interaction cakephp/app:^4.5 .
 RUN composer config minimum-stability dev
 RUN composer config prefer-stable true
 RUN composer update -W

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -11,6 +11,8 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 RUN composer create-project --prefer-dist --no-interaction cakephp/app .
 RUN composer config minimum-stability dev
 RUN composer config prefer-stable true
+RUN composer update -W
+RUN composer dump-autoload
 RUN composer require cnizzardini/cakephp-preloader:$BRANCH
 RUN bin/cake plugin load CakePreloader
 RUN bin/cake preloader

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -10,8 +10,10 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 RUN composer create-project --prefer-dist --no-interaction cakephp/app .
 RUN composer require cnizzardini/cakephp-preloader:$BRANCH
-COPY plugins.php /srv/app/config/plugins.php
+RUN sleep 5
 RUN bin/cake plugin load CakePreloader
+RUN sleep 1
 RUN bin/cake preloader
+RUN sleep 1
 
 CMD ["php-fpm"]

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,7 +1,6 @@
 FROM cnizzardini/php-fpm-alpine:8.0-latest
 
 ARG BRANCH=main
-ARG CAKE_VERSION
 
 COPY php.ini /usr/local/etc/php/php.ini
 
@@ -11,7 +10,7 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 RUN composer create-project --prefer-dist --no-interaction cakephp/app .
 RUN composer require cnizzardini/cakephp-preloader:$BRANCH
-RUN bin/cake plugin load CakePreloader
+COPY plugins.php /srv/app/config/plugins.php
 RUN bin/cake preloader
 
 CMD ["php-fpm"]

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -12,8 +12,8 @@ RUN composer create-project --prefer-dist --no-interaction cakephp/app .
 RUN composer config minimum-stability dev
 RUN composer config prefer-stable true
 RUN composer update -W
-RUN composer dump-autoload
 RUN composer require cnizzardini/cakephp-preloader:$BRANCH
+RUN composer dump-autoload
 RUN bin/cake plugin load CakePreloader
 RUN bin/cake preloader
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM cnizzardini/php-fpm-alpine:8.1-latest
+FROM cnizzardini/php-fpm-alpine:8.0-latest
 
 ARG BRANCH=main
 
@@ -8,9 +8,9 @@ WORKDIR /srv/app
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-RUN composer create-project --prefer-dist --no-interaction cakephp/app:^4.5 .
+RUN composer create-project --prefer-dist --no-interaction cakephp/app:~4.2.0 .
 RUN composer require cnizzardini/cakephp-preloader:$BRANCH
-COPY plugins.php /srv/app/config/plugins.php
+RUN bin/cake plugin load CakePreloader
 RUN bin/cake preloader
 
 CMD ["php-fpm"]

--- a/tests/TestCase/Command/PreloaderCommandTest.php
+++ b/tests/TestCase/Command/PreloaderCommandTest.php
@@ -51,9 +51,8 @@ class PreloaderCommandTest extends TestCase
         $contains = [
             'vendor/autoload.php',
             'vendor/cakephp/cakephp/src/Cache/Cache.php',
-            'vendor/cakephp/cakephp/src/basics.php',
             'require_once',
-            'opcache_compile_file'
+            //'opcache_compile_file',
         ];
 
         foreach ($contains as $file) {

--- a/tests/php.ini
+++ b/tests/php.ini
@@ -1,11 +1,11 @@
 ;
 ; Development
 ;
-extension=intl.so
-extension=pdo_mysql.so
-extension=sodium
-extension=zip.so
-zend_extension=opcache.so
+;extension=intl.so
+;extension=pdo_mysql.so
+;extension=sodium
+;extension=zip.so
+;zend_extension=opcache.so
 
 [php]
 session.auto_start = Off

--- a/tests/plugins.php
+++ b/tests/plugins.php
@@ -1,0 +1,6 @@
+<?php
+declare(strict_types=1);
+
+return [
+    'CakePreloader' => [],
+];

--- a/tests/plugins.php
+++ b/tests/plugins.php
@@ -1,6 +1,0 @@
-<?php
-declare(strict_types=1);
-
-return [
-    'CakePreloader' => [],
-];


### PR DESCRIPTION
Resolves #19 

- Adds cake 4.5 to pipeline and refactors actions a bit
- Set php constraint to 7.4|8.0
- Update version constraint for phpstan (dev dependency only)