### PR TITLE
Add support for specifying a base path via CLI argument

### DIFF
--- a/src/Command/PreloaderCommand.php
+++ b/src/Command/PreloaderCommand.php
@@ -73,6 +73,9 @@ class PreloaderCommand extends Command
             ->addOption('name', [
                 'help' => 'The preload file path (default: ROOT . DS . preload.php)',
             ])
+            ->addOption('basePath', [
+                'help' => 'Path to scan for classes, packages, and plugins (default: ROOT)',
+            ])
             ->addOption('app', [
                 'help' => 'Add your applications src directory into the preloader',
                 'boolean' => true,

--- a/src/PreloaderService.php
+++ b/src/PreloaderService.php
@@ -58,7 +58,7 @@ class PreloaderService
     private function cakephp(Arguments $args, ConsoleIo $io): void
     {
         $preloadPath = CAKE;
-        if ($preloadPath = $args->getOption('basePath')) {
+        if ($basePath = $args->getOption('basePath')) {
             $io->out('<info>Using custom base path for Cake: ' . $basePath . '</info>');
             $preloadPath = str_replace(ROOT, $basePath, $preloadPath);
         }
@@ -85,7 +85,7 @@ class PreloaderService
         }       
 
         $preloadPath = ROOT;
-        if ($preloadPath = $args->getOption('basePath')) {
+        if ($basePath = $args->getOption('basePath')) {
             $io->out('<info>Using custom base path for Packages: ' . $basePath . '</info>');
             $preloadPath = str_replace(ROOT, $basePath, $preloadPath);
         }
@@ -136,7 +136,7 @@ class PreloaderService
         }
 
         $preloadPath = APP;
-        if ($preloadPath = $args->getOption('basePath')) {
+        if ($basePath = $args->getOption('basePath')) {
             $io->out('<info>Using custom base path for App: ' . $basePath . '</info>');
             $preloadPath = str_replace(ROOT, $basePath, $preloadPath);
         }
@@ -168,7 +168,7 @@ class PreloaderService
         }       
 
         $preloadPath = ROOT;
-        if ($preloadPath = $args->getOption('basePath')) {
+        if ($basePath = $args->getOption('basePath')) {
             $io->out('<info>Using custom base path for Plugins: ' . $basePath . '</info>');
             $preloadPath = str_replace(ROOT, $basePath, $preloadPath);
         }


### PR DESCRIPTION
In some cases users may want to override the base path of the files written to `preload.php`. Note that this is _not_ the same as selecting the location where `preload.php` gets generated. For example, `/usr/src/app` vs. `/var/www/html`. Currently the plugin just uses the default framework ROOT in all places.